### PR TITLE
Compatibility shims for Python 3.3.4

### DIFF
--- a/mf2py/dom_helpers.py
+++ b/mf2py/dom_helpers.py
@@ -1,5 +1,12 @@
 from bs4 import Tag as bs4Tag
 
+import sys
+if sys.version < '3':
+    text_type = unicode
+    binary_type = str
+else:
+    text_type = str
+    binary_type = bytes
 
 ## function to check if an element is a Tag or not.
 def is_tag(el):
@@ -15,7 +22,7 @@ def get_attr(el, attr, check_name=None ):
     else:
         attr_value = None
 
-    if isinstance(attr_value, str) or isinstance(attr_value, unicode):
+    if isinstance(attr_value, text_type) or isinstance(attr_value, binary_type):
         if attr_value.strip() == "":
             attr_value = None
 

--- a/mf2py/implied_properties.py
+++ b/mf2py/implied_properties.py
@@ -1,5 +1,5 @@
-import mf2_classes
-from dom_helpers import get_attr 
+from mf2py import mf2_classes
+from mf2py.dom_helpers import get_attr 
 
 ## function to find an implied name property
 def name(el):

--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -1,6 +1,15 @@
 from bs4 import Tag
-from dom_helpers import get_attr
-from urlparse import urljoin
+from mf2py.dom_helpers import get_attr
+import sys
+if sys.version < '3':
+    from urlparse import urljoin
+    text_type = unicode
+    binary_type = str
+else:
+    from urllib.parse import urljoin
+    text_type = str
+    binary_type = bytes
+
 ## functions to parse the propertis of elements
 
 def text(el):
@@ -70,6 +79,6 @@ def datetime(el):
 def embedded(el):
 
     return {
-                'html': ''.join([unicode(e) for e in el.children]),
+                'html': ''.join([text_type(e) for e in el.children]),
                 'value': el.get_text()     # strip here?
             }

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -3,9 +3,14 @@
 import json
 from bs4 import BeautifulSoup
 import requests
-from urlparse import urlparse, urljoin
-from dom_helpers import is_tag, get_attr
-import backcompat, mf2_classes, implied_properties, parse_property
+from mf2py.dom_helpers import is_tag, get_attr
+from mf2py import backcompat, mf2_classes, implied_properties, parse_property
+import sys
+if sys.version < '3':
+    from urlparse import urlparse, urljoin
+else:
+    from urllib.parse import urlparse, urljoin
+
 
 class Parser(object):
     """Object to parse a document for microformats and return them in appropriate formats.
@@ -70,16 +75,16 @@ class Parser(object):
         # set of all parsed things
         parsed = set()
 
-        ## function for handling a root microformat i.e. h-*        
+        ## function for handling a root microformat i.e. h-*
         def handle_microformat(root_class_names, el, is_nested=True):
 
             # parse for properties and children
             properties, children = parse_props(el, True)
-           
-            # if some properties not already found find in implied ways 
+
+            # if some properties not already found find in implied ways
             if 'name' not in properties:
                 properties["name"] = implied_properties.name(el)
-                
+
             if "photo" not in properties:
                 x = implied_properties.photo(el)
                 if x is not None:
@@ -100,7 +105,7 @@ class Parser(object):
             if is_nested:
                 microformat["value"] = str(el)
             return microformat
-        
+
         ## function to parse properties of element
         def parse_props(el, is_root_element=False):
 
@@ -150,22 +155,22 @@ class Parser(object):
                             value = parse_property.url(el, base_url=self.__url__)
 
                         prop_value.append(value)
-                        
+
                         if prop_value is not []:
                             props[prop_name] = prop_value
-                    
+
                     # Parse datetime dt-* properties.
                     value = None
                     for prop in mf2_classes.datetime(classes):
                         prop_name = prop[3:]
                         prop_value = props.get(prop_name, [])
-                        
+
                         # if value has not been parsed then parse it
                         if value is None:
                             value = parse_property.datetime(el)
 
                         prop_value.append(value)
-                        
+
                         if prop_value is not []:
                             props[prop_name] = prop_value
 
@@ -174,16 +179,16 @@ class Parser(object):
                     for prop in mf2_classes.embedded(classes):
                         prop_name = prop[2:]
                         prop_value = props.get(prop_name, [])
-                        
+
                         # if value has not been parsed then parse it
                         if value is None:
                             value = parse_property.embedded(el)
 
                         prop_value.append(value)
-                        
+
                         if prop_value is not []:
                             props[prop_name] = prop_value
-            
+
             parsed.add(el)
 
             # parse children if they are tags and not already parsed
@@ -194,7 +199,7 @@ class Parser(object):
                     v.extend(child_properties[prop_name])
                     props[prop_name] = v
                 children.extend(child_microformats)
-            
+
             return props, children
 
 
@@ -268,6 +273,6 @@ class Parser(object):
     ## function to get a python dictionary version of parsed microformat
     def to_dict(self):
         return self.__parsed__
-    ## function to get a json version of parsed microformat    
+    ## function to get a json version of parsed microformat
     def to_json(self):
         return json.dumps(self.to_dict())


### PR DESCRIPTION
These are the minor changes I made to work with Python 3.3.4 that _should_ be totally backward compatible with 2.7. And sorry about the trailing whitespace changes -- my emacs does that automatically. I can rebase them out if you'd like. Thanks!
