### PR TITLE
Reorganize parsing logic, attempting to simplify traversal.

### DIFF
--- a/test/examples/nested_hcards.html
+++ b/test/examples/nested_hcards.html
@@ -1,0 +1,8 @@
+<!--
+    Without the 'visited' set, p-name is incorrectly being hoisted to
+    the parent h-card
+  -->
+<div class="post reply h-entry ">
+    <p class="p-in-reply-to h-cite"><span class="p-name">KP</span></p>
+    <p class="p-author h-card"><span class="p-name">KP1</span></p>
+</div>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,126 +1,211 @@
 # coding: utf-8
 
-import nose
+from nose.tools import assert_equal, assert_true
 import os.path
 from pprint import pprint
 from mf2py.parser import Parser
+
 
 def parse_fixture(path):
     p = Parser(doc=open(os.path.join("test/examples/", path)))
     return p.to_dict()
 
+
 def test_empty():
-   p = Parser()
-   assert type(p) is not None
-   assert type(p.to_dict()) is dict
+    p = Parser()
+    assert_true(type(p) is not None)
+    assert_true(type(p.to_dict()) is dict)
+
 
 def test_open_file():
-   p = Parser(doc=open("test/examples/empty.html"))
-   assert p.__doc__ is not None
-   assert type(p) is not None
-   assert type(p.to_dict()) is dict
+    p = Parser(doc=open("test/examples/empty.html"))
+    assert_true(p.__doc__ is not None)
+    assert_true(type(p) is not None)
+    assert_true(type(p.to_dict()) is dict)
+
 
 def test_user_agent():
-    assert Parser.useragent == 'mf2py - microformats2 parser for python'
+    assert_equal(Parser.useragent, 'mf2py - microformats2 parser for python')
     Parser.useragent = 'something else'
-    assert Parser.useragent == 'something else'
+    assert_equal(Parser.useragent, 'something else')
     # set back to default. damn stateful classes
     Parser.useragent = 'mf2py - microformats2 parser for python'
 
+
 def test_base():
     p = Parser(doc=open("test/examples/base.html"))
-    assert p.__url__ == u"http://tantek.com/"
+    assert_equal(p.__url__, u"http://tantek.com/")
+
 
 def test_simple_parse():
     result = parse_fixture("simple_person_reference.html")
-    assert result["items"][0]["properties"] == {u'name': [u'Frances Berriman']}
+    assert_equal(result["items"][0]["properties"],
+                 {u'name': [u'Frances Berriman']})
+
 
 def test_simple_person_reference_implied():
     p = Parser(doc=open("test/examples/simple_person_reference_implied.html"))
     result = p.to_dict()
-    assert result["items"][0]["properties"] == {u'name': [u'Frances Berriman']}
+    assert_equal(result["items"][0]["properties"],
+                 {u'name': [u'Frances Berriman']})
+
 
 def test_simple_person_reference_same_element():
     result = parse_fixture("simple_person_reference_same_element.html")
-    assert result["items"][0]["properties"] == {u'name': [u'Frances Berriman']}
+    assert_equal(result["items"][0]["properties"],
+                 {u'name': [u'Frances Berriman']})
+
 
 def test_person_with_url():
     p = Parser(doc=open("test/examples/person_with_url.html"))
     result = p.to_dict()
-    assert result["items"][0]["properties"]["name"] == [u'Tom Morris']
-    assert result["items"][0]["properties"]["url"] == [u'http://tommorris.org/']
+    assert_equal(result["items"][0]["properties"]["name"],
+                 [u'Tom Morris'])
+    assert_equal(result["items"][0]["properties"]["url"],
+                 [u'http://tommorris.org/'])
+
 
 def test_vcp():
     result = parse_fixture("value_class_person.html")
-    assert result["items"][0]["properties"]["tel"] == [u'+44 1234 567890']
+    assert_equal(result["items"][0]["properties"]["tel"], [u'+44 1234 567890'])
+
 
 def test_multiple_root_classnames():
     result = parse_fixture("nested_multiple_classnames.html")
     # order does not matter
-    assert len(result["items"]) == 1
-    assert set(result["items"][0]["type"]) == set(["h-entry", "h-as-note"])
+    assert_equal(len(result["items"]), 1)
+    assert_equal(set(result["items"][0]["type"]),
+                 set(["h-entry", "h-as-note"]))
+
 
 def test_property_nested_microformat():
     result = parse_fixture("nested_multiple_classnames.html")
 
-    assert len(result["items"]) == 1
+    assert_equal(len(result["items"]), 1)
     assert "author" in result["items"][0]["properties"]
-    assert result["items"][0]["properties"]["author"][0]["properties"]["name"][0] == "Tom Morris"
-    assert result["items"][0]["properties"]["reviewer"][0]["properties"]["name"][0] == "Tom Morris"
-    assert result["items"][0]["properties"]["author"][0]["properties"]["adr"][0]["properties"]["city"][0] == "London"
+    assert_equal(
+        result["items"][0]["properties"]["author"][0]["properties"]["name"][0],
+        "Tom Morris")
+    assert_equal(
+        result["items"][0]["properties"]["reviewer"][0]
+        ["properties"]["name"][0],
+        "Tom Morris")
+    assert_equal(
+        result["items"][0]["properties"]["author"][0]
+        ["properties"]["adr"][0]["properties"]["city"][0],
+        "London")
+
 
 def test_plain_child_microformat():
     result = parse_fixture("nested_multiple_classnames.html")
 
-    assert len(result["items"]) == 1
-    assert "children" in result["items"][0]
-    assert len(result["items"][0]["children"]) == 1
-    assert result["items"][0]["children"][0]["properties"]["name"][0] == "Some Citation"
+    assert_equal(len(result["items"]), 1)
+    assert_true("children" in result["items"][0])
+    assert_equal(len(result["items"][0]["children"]), 1)
+    assert_equal(
+        result["items"][0]["children"][0]["properties"]["name"][0],
+        "Some Citation")
+
 
 def test_implied_name():
     result = parse_fixture("implied_properties.html")
-    assert result["items"][0]["properties"]["name"][0] == "Tom Morris"
+    assert_equal(result["items"][0]["properties"]["name"][0], "Tom Morris")
+
 
 def test_implied_url():
     result = parse_fixture("implied_properties.html")
-    assert result["items"][1]["properties"]["url"][0] == "http://tommorris.org/"
+    assert_equal(result["items"][1]["properties"]["url"][0],
+                 "http://tommorris.org/")
+
 
 def test_implied_nested_photo():
     result = parse_fixture("implied_properties.html")
-    assert result["items"][2]["properties"]["photo"][0] == "http://tommorris.org/photo.png"
+    assert_equal(result["items"][2]["properties"]["photo"][0],
+                 "http://tommorris.org/photo.png")
+
 
 def test_implied_nested_photo_alt_name():
     result = parse_fixture("implied_properties.html")
-    assert result["items"][3]["properties"]["name"][0] == "Tom Morris"
+    assert_equal(result["items"][3]["properties"]["name"][0], "Tom Morris")
+
 
 def test_implied_image():
     result = parse_fixture("implied_properties.html")
-    assert result["items"][4]["properties"]["photo"][0] == "http://tommorris.org/photo.png"
-    assert result["items"][4]["properties"]["name"][0] == "Tom Morris"
+    assert_equal(result["items"][4]["properties"]["photo"][0],
+                 "http://tommorris.org/photo.png")
+    assert_equal(result["items"][4]["properties"]["name"][0], "Tom Morris")
+
 
 def test_datetime_parsing():
     result = parse_fixture("datetimes.html")
-    assert result["items"][0]["properties"]["start"][0] == "2014-01-01T12:00:00+00:00"
-    assert result["items"][0]["properties"]["end"][0] == "3014-01-01T18:00:00+00:00"
-    assert result["items"][0]["properties"]["duration"][0] == "P1000Y"
-    assert result["items"][0]["properties"]["updated"][0] == "2011-08-26T00:01:21+00:00"
-    assert result["items"][0]["properties"]["updated"][1] == "2011-08-26T00:01:21+00:00"
+    assert_equal(result["items"][0]["properties"]["start"][0],
+                 "2014-01-01T12:00:00+00:00")
+    assert_equal(result["items"][0]["properties"]["end"][0],
+                 "3014-01-01T18:00:00+00:00")
+    assert_equal(result["items"][0]["properties"]["duration"][0],
+                 "P1000Y")
+    assert_equal(result["items"][0]["properties"]["updated"][0],
+                 "2011-08-26T00:01:21+00:00")
+    assert_equal(result["items"][0]["properties"]["updated"][1],
+                 "2011-08-26T00:01:21+00:00")
+
 
 def test_datetime_vcp_parsing():
     result = parse_fixture("datetimes.html")
-    assert result["items"][1]["properties"]["published"][0] == "3014-01-01T01:21+00:00"
-    assert result["items"][2]["properties"]["updated"][0] == "2014-03-11T09:55"
-    assert result["items"][3]["properties"]["published"][0] == "2014-01-30T15:28"
-    assert result["items"][4]["properties"]["published"][0] == "9999-01-14T11:52+08:00"
+    assert_equal(result["items"][1]["properties"]["published"][0],
+                 "3014-01-01T01:21+00:00")
+    assert_equal(result["items"][2]["properties"]["updated"][0],
+                 "2014-03-11T09:55")
+    assert_equal(result["items"][3]["properties"]["published"][0],
+                 "2014-01-30T15:28")
+    assert_equal(result["items"][4]["properties"]["published"][0],
+                 "9999-01-14T11:52+08:00")
+
 
 def test_embedded_parsing():
     result = parse_fixture("embedded.html")
-    assert result["items"][0]["properties"]["content"][0]["html"] == '\n   <p>Blah blah blah blah blah.</p>\n   <p>Blah.</p>\n   <p>Blah blah blah.</p>\n  '
-    assert result["items"][0]["properties"]["content"][0]["value"] == '\n   Blah blah blah blah blah.\n   Blah.\n   Blah blah blah.\n  '
+    assert_equal(
+        result["items"][0]["properties"]["content"][0]["html"],
+        '\n   <p>Blah blah blah blah blah.</p>\n   <p>Blah.</p>\n   <p>Blah blah blah.</p>\n  ')
+    assert_equal(
+        result["items"][0]["properties"]["content"][0]["value"],
+        '\n   Blah blah blah blah blah.\n   Blah.\n   Blah blah blah.\n  ')
+
 
 def test_backcompat():
     result = parse_fixture("backcompat.html")
-    assert set(result["items"][0]["type"]) == set(["h-card"])
+    assert_equal(set(result["items"][0]["type"]), set(["h-card"]))
+
+
+def test_hoisting_nested_hcard():
+    result = parse_fixture("nested_hcards.html")
+    expected = {
+        'items': [
+            {
+                'properties': {
+                    'author': [
+                        {
+                            'properties': {u'name': [u'KP1']},
+                            'type': [u'h-card'],
+                            'value': u'KP1'
+                        }
+                    ],
+                    'in-reply-to': [
+                        {
+                            'properties': {u'name': [u'KP']},
+                            'type': [u'h-cite'],
+                            'value': u'KP'
+                        }
+                    ],
+                    'name': [u'KP\n    KP1']
+                },
+                'type': ['h-entry']
+            }
+        ],
+        'rels': {}
+    }
+    assert_equal([u'KP\n    KP1'], result['items'][0]['properties']['name'])
+    assert_equal(expected, result)
 
 if __name__ == '__main__':
     result = parse_fixture("nested_multiple_classnames.html")


### PR DESCRIPTION
- handle_microformats: calls parse_props recursively on its _children_
  rather than on itself with a special flag for is_root_element
- parse_props: only recurses in to child properties if the current
  element is not part of a nested microformat (otherwise, the nested properties
  will be handled by the recursive call to handle_microformats)
- added a test for the case Kartik discovered, where p-names in nested
  h-cards were hoisted to the parent h-card
- use assert_equal instead of assert ... == in nose tests for more
  informative print outs

ref issue #29  
