### PR TITLE
Added workaround for bs4/html5lib bug that prevents it from parsing

### DIFF
--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -244,7 +244,15 @@ class Parser(object):
         ## function to parse an element for microformats
         def parse_el(el, ctx, top_level=False):
 
-            classes = el.get("class",[])
+            classes = el.get("class", [])
+
+            # Workaround for bs4+html5lib bug that
+            # prevents it from recognizing multi-valued
+            # attrs on the <html> element
+            # https://bugs.launchpad.net/beautifulsoup/+bug/1296481
+            if el.name == 'html' and not isinstance(classes, list):
+                classes = classes.split()
+
             # find potential microformats in root classnames h-*
             potential_microformats = mf2_classes.root(classes)
 

--- a/test/examples/hfeed_on_html_tag.html
+++ b/test/examples/hfeed_on_html_tag.html
@@ -1,0 +1,16 @@
+<html class="h-feed" lang="en">
+  <head>
+    <title>html tag with class h-feed</title>
+  </head>
+  <body>
+
+    <article class="h-entry">
+      <p class="name">entry1</p>
+    </article>
+
+    <article class="h-entry">
+      <p class="name">entry2</p>
+    </article>
+
+  </body>
+</html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -207,6 +207,16 @@ def test_hoisting_nested_hcard():
     assert_equal([u'KP\n    KP1'], result['items'][0]['properties']['name'])
     assert_equal(expected, result)
 
+
+def test_html_tag_class():
+    result = parse_fixture("hfeed_on_html_tag.html")
+    assert_equal([u'h-feed'], result['items'][0]['type'])
+
+    assert_equal([u'entry1'], result['items'][0]['children'][0]['properties']['name'])
+    assert_equal([u'entry2'], result['items'][0]['children'][1]['properties']['name'])
+
+
+
 if __name__ == '__main__':
     result = parse_fixture("nested_multiple_classnames.html")
     pprint(result)


### PR DESCRIPTION
multi-valued attributes on the &lt;html&gt; tag (addresses issue #31)
