### PR TITLE
Bugfix for nested datetimes & Implied date for dt-* properties

### DIFF
--- a/mf2py/parse_property.py
+++ b/mf2py/parse_property.py
@@ -15,8 +15,8 @@ else:
 ## functions to parse the properties of elements
 
 DATE_RE = r'(\d{4})-(\d{2})-(\d{2})'
-TIME_RE = r'(\d{2}):(\d{2})(?::(\d{2}))?(?:(Z)|([+-]\d{2}:?\d{2}))?'
-DATETIME_RE = DATE_RE + 'T' + TIME_RE
+TIME_RE = r'(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(?:(Z)|([+-]\d{2}:?\d{2}))?'
+DATETIME_RE = r'(?P<date>%s)T(?P<time>%s)' % (DATE_RE, TIME_RE)
 
 
 def text(el):
@@ -68,7 +68,11 @@ def url(el, base_url=''):
     # strip here?
     return el.get_text()
 
-def datetime(el):
+def datetime(el, default_date=None):
+    """
+    :param el: Tag containing the dt-value
+    :return: a tuple of two strings, (datetime, date)
+    """
     # handle value-class-pattern
     value_els = el.find_all(class_='value')
     if value_els:
@@ -95,37 +99,42 @@ def datetime(el):
                 if val:
                     date_parts.append(val.strip())
 
-        date_part = ''
-        time_part = ''
-        date_time_value = ''
+        date_part = default_date
+        time_part = None
         for part in date_parts:
-            if re.match(DATETIME_RE, part):
+            match = re.match(DATETIME_RE + '$', part)
+            if match:
                 # if it's a full datetime, then we're done
-                date_time_value = part
+                date_part = match.group('date')
+                time_part = match.group('time')
                 break
-            else:
-                if re.match(TIME_RE, part):
-                    time_part = part
-                elif re.match(DATE_RE, part):
-                    date_part = part
-                date_time_value = (date_part.strip().rstrip('T')
-                                   + 'T' + time_part.strip())
-        return date_time_value
+            elif re.match(TIME_RE + '$', part):
+                time_part = part
+            elif re.match(DATE_RE + '$', part):
+                date_part = part
 
-    prop_value = get_attr(el, "datetime", check_name=("time","ins","del"))
-    if prop_value is not None:
-        return prop_value
+        if date_part and time_part:
+            date_time_value = '%sT%s' % (date_part,
+                                         time_part)
+        else:
+            date_time_value = date_part or time_part
 
-    prop_value = get_attr(el, "title", check_name="abbr")
-    if prop_value is not None:
-        return prop_value
+        return date_time_value, date_part
 
-    prop_value = get_attr(el, "value", check_name=("data","input"))
-    if prop_value is not None:
-        return prop_value
+    prop_value = get_attr(el, "datetime", check_name=("time", "ins", "del"))\
+        or get_attr(el, "title", check_name="abbr")\
+        or get_attr(el, "value", check_name=("data", "input"))\
+        or el.get_text()  # strip here?
 
-    # strip here?
-    return el.get_text()
+    # if this is just a time, augment with default date
+    match = re.match(TIME_RE + '$', prop_value)
+    if match and default_date:
+        prop_value = '%sT%s' % (default_date, prop_value)
+        return prop_value, default_date
+
+    # otherwise, treat it as a full date
+    match = re.match(DATETIME_RE + '$', prop_value)
+    return prop_value, match and match.group('date'),
 
 def embedded(el):
 

--- a/mf2py/parser.py
+++ b/mf2py/parser.py
@@ -85,13 +85,14 @@ class Parser(object):
 
     ## function to parse the document
     def parse(self):
-        # set of all parsed things
-        #parsed = set()
+        self._default_date = None
+
 
         ## function for handling a root microformat i.e. h-*
         def handle_microformat(root_class_names, el, is_nested=True):
             properties = {}
             children = []
+            self._default_date = None
 
             # parse for properties and children
             for child in el.find_all(True, recursive=False):
@@ -183,7 +184,11 @@ class Parser(object):
 
                     # if value has not been parsed then parse it
                     if value is None:
-                        value = parse_property.datetime(el)
+                        value, new_date = parse_property.datetime(
+                            el, self._default_date)
+                        # update the default date
+                        if new_date:
+                            self._default_date = new_date
 
                     prop_value.append(value)
 
@@ -204,7 +209,7 @@ class Parser(object):
                     if prop_value is not []:
                         props[prop_name] = prop_value
 
-                # parse child tags, provided this isn't a microformat
+                # parse child tags, provided this isn't a microformat root-class
                 for child in el.find_all(True, recursive=False):
                     child_properties, child_microformats = parse_props(child)
                     for prop_name in child_properties:

--- a/test/examples/datetimes.html
+++ b/test/examples/datetimes.html
@@ -38,13 +38,42 @@
    </span>
  </div>
 
-
  <div class="h-entry">
    <!-- wiki event with UTC offset -->
    <span class="dt-published">
      <span class="value" title="June 1, 2014">2014-06-01</span>
      <span class="value" title="12:30">12:30<span style="display: none;">-06:00</span></span>
    </span>
+ </div>
+
+ <div class="h-event">
+   <h1 class="p-name">Implied Date wo Timezone</h1>
+
+   This test case and the next are courtesy of event templates on
+   http://indiewebcamp.com/User:Gregorlove.com/sandbox
+
+   <p> When:
+     <span class="dt-start">
+       <span class="value" title="May 21, 2014">2014-05-21</span>
+       <span class="value" title="18:30">18:30</span>
+       –
+       <span class="dt-end">19:30</span>
+     </span> (local time)
+   </p>
+ </div>
+
+ <div class="h-event">
+   <h1 class="p-name">Implied Date w/ Timezone</h1>
+
+   <p> When:
+     <span class="dt-start">
+       <span class="value" title="June 1, 2014">2014-06-01</span>
+       <span class="value" title="12:30">12:30<span style="display: none;">-06:00</span></span>
+       –
+       <span class="dt-end">19:30<span style="display: none;">-06:00</span></span>
+     </span> (-06:00 <abbr>UTC</abbr>)
+   </p>
+
  </div>
 
 </body>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -163,6 +163,23 @@ def test_datetime_vcp_parsing():
     assert_equal(result["items"][5]["properties"]["published"][0],
                  "2014-06-01T12:30-06:00")
 
+def test_dt_end_implied_date():
+    """Test that events with dt-start and dt-end use the implied date
+    rules http://microformats.org/wiki/value-class-pattern#microformats2_parsers
+    for times without dates"""
+    result = parse_fixture("datetimes.html")
+
+    event_wo_tz = result["items"][6]
+    assert_equal(event_wo_tz["properties"]["start"][0],
+                 "2014-05-21T18:30")
+    assert_equal(event_wo_tz["properties"]["end"][0],
+                 "2014-05-21T19:30")
+
+    event_w_tz = result["items"][7]
+    assert_equal(event_w_tz["properties"]["start"][0],
+                 "2014-06-01T12:30-06:00")
+    assert_equal(event_w_tz["properties"]["end"][0],
+                 "2014-06-01T19:30-06:00")
 
 def test_embedded_parsing():
     result = parse_fixture("embedded.html")


### PR DESCRIPTION
This is a two-parter, both necessary to correctly process 

  http://indiewebcamp.com/User:Gregorlove.com/sandbox

Part 1, value-class-pattern was slightly broken for cases like 

```
<span class="value">19:30 <span style="display:none">-0600</span></span>
```

because BS4's Tag.string attribute would return None. replaced the call with Tag.get_text() and it works.

Part 2, According to http://microformats.org/wiki/value-class-pattern#microformats2_parsers, if a dt-\* property omits the date, we should use the most recent date. This handles the case where an event as dt-start=datetime and dt-end=time, without special-casing for specific property names. I added a private member variable to Parser: `_default_date` to track the current date.

Note: the spec also says that if there was no previously parsed date, we should use the _next_ date. This is sufficiently difficult that I think we should wait until we see at least one example in the wild.

cc: @gregorlove, @barnabywalters
