### PR TITLE
add rel-bookmark -> u-url translation to backcompat module.

### DIFF
--- a/mf2py/backcompat.py
+++ b/mf2py/backcompat.py
@@ -18,104 +18,126 @@ CLASSIC_ROOT_MAP = {
 
 CLASSIC_PROPERTY_MAP = {
     'vcard': {
-        'fn': ['p-name'],
-        'url': ['u-url'],
-        'honorific-prefix': ['p-honorific-prefix'],
-        'given-name': ['p-given-name'],
-        'additional-name': ['p-additional-name'],
-        'family-name': ['p-family-name'],
-        'honorific-suffix': ['p-honorific-suffix'],
-        'nickname': ['p-nickname'],
-        'email': ['u-email'],
-        'logo': ['u-logo'],
-        'photo': ['u-photo'],
-        'url': ['u-url'],
-        'uid': ['u-uid'],
-        'category': ['p-category'],
-        'adr': ['p-adr', 'h-adr'],
-        'extended-address': ['p-extended-address'],
-        'street-address': ['p-street-address'],
-        'locality': ['p-locality'],
-        'region': ['p-region'],
-        'postal-code': ['p-postal-code'],
-        'country-name': ['p-country-name'],
-        'label': ['p-label'],
-        'geo': ['p-geo', 'h-geo'],
-        'latitude': ['p-latitude'],
-        'longitude': ['p-longitude'],
-        'tel': ['p-tel'],
-        'note': ['p-note'],
-        'bday': ['dt-bday'],
-        'key': ['u-key'],
-        'org': ['p-org'],
-        'organization-name': ['p-organization-name'],
-        'organization-unit': ['p-organization-unit'],
+        'classes': {
+            'fn': ['p-name'],
+            'url': ['u-url'],
+            'honorific-prefix': ['p-honorific-prefix'],
+            'given-name': ['p-given-name'],
+            'additional-name': ['p-additional-name'],
+            'family-name': ['p-family-name'],
+            'honorific-suffix': ['p-honorific-suffix'],
+            'nickname': ['p-nickname'],
+            'email': ['u-email'],
+            'logo': ['u-logo'],
+            'photo': ['u-photo'],
+            'url': ['u-url'],
+            'uid': ['u-uid'],
+            'category': ['p-category'],
+            'adr': ['p-adr', 'h-adr'],
+            'extended-address': ['p-extended-address'],
+            'street-address': ['p-street-address'],
+            'locality': ['p-locality'],
+            'region': ['p-region'],
+            'postal-code': ['p-postal-code'],
+            'country-name': ['p-country-name'],
+            'label': ['p-label'],
+            'geo': ['p-geo', 'h-geo'],
+            'latitude': ['p-latitude'],
+            'longitude': ['p-longitude'],
+            'tel': ['p-tel'],
+            'note': ['p-note'],
+            'bday': ['dt-bday'],
+            'key': ['u-key'],
+            'org': ['p-org'],
+            'organization-name': ['p-organization-name'],
+            'organization-unit': ['p-organization-unit'],
+        },
     },
     'hentry': {
-        'entry-title': ['p-name'],
-        'entry-summary': ['p-summary'],
-        'entry-content': ['e-content'],
-        'published': ['dt-published'],
-        'updated': ['dt-updated'],
-        'author': ['p-author', 'h-card'],
-        'category': ['p-category'],
-        'geo': ['p-geo', 'h-geo'],
-        'latitude': ['p-latitude'],
-        'longitude': ['p-longitude'],
+        'classes': {
+            'entry-title': ['p-name'],
+            'entry-summary': ['p-summary'],
+            'entry-content': ['e-content'],
+            'published': ['dt-published'],
+            'updated': ['dt-updated'],
+            'author': ['p-author', 'h-card'],
+            'category': ['p-category'],
+            'geo': ['p-geo', 'h-geo'],
+            'latitude': ['p-latitude'],
+            'longitude': ['p-longitude'],
+        },
+        'rels': {
+            # Unlike most rel values, bookmark is scoped to its
+            # parent, not to the document.
+            'bookmark': ['u-url'],
+        },
     },
     'hrecipe': {
-        'fn': ['p-name'],
-        'ingredient': ['p-ingredient'],
-        'yield': ['p-yield'],
-        'instructions': ['e-instructions'],
-        'duration': ['dt-duration'],
-        'nutrition': ['p-nutrition'],
-        'photo': ['u-photo'],
-        'summary': ['p-summary'],
-        'author': ['p-author', 'h-card'],
+        'classes': {
+            'fn': ['p-name'],
+            'ingredient': ['p-ingredient'],
+            'yield': ['p-yield'],
+            'instructions': ['e-instructions'],
+            'duration': ['dt-duration'],
+            'nutrition': ['p-nutrition'],
+            'photo': ['u-photo'],
+            'summary': ['p-summary'],
+            'author': ['p-author', 'h-card'],
+        },
     },
     'hresume': {
-        'summary': ['p-summary'],
-        'contact': ['h-card', 'p-contact'],
-        'education': ['h-event', 'p-education'],
-        'experience': ['h-event', 'p-experience'],
-        'skill': ['p-skill'],
-        'affiliation': ['p-affiliation', 'h-card'],
+        'classes': {
+            'summary': ['p-summary'],
+            'contact': ['h-card', 'p-contact'],
+            'education': ['h-event', 'p-education'],
+            'experience': ['h-event', 'p-experience'],
+            'skill': ['p-skill'],
+            'affiliation': ['p-affiliation', 'h-card'],
+        },
     },
     'hevent': {
-        'dtstart': ['dt-start'],
-        'dtend': ['dt-end'],
-        'duration': ['dt-duration'],
-        'description': ['p-description'],
-        'summary': ['p-summary'],
-        'description': ['p-description'],
-        'url': ['u-url'],
-        'category': ['p-category'],
-        'location': ['h-card'],
-        'geo': ['p-location h-geo'],
+        'classes': {
+            'dtstart': ['dt-start'],
+            'dtend': ['dt-end'],
+            'duration': ['dt-duration'],
+            'description': ['p-description'],
+            'summary': ['p-summary'],
+            'description': ['p-description'],
+            'url': ['u-url'],
+            'category': ['p-category'],
+            'location': ['h-card'],
+            'geo': ['p-location h-geo'],
+        },
     },
     'hreview': {
-        'summary': ['p-name'],
-        'fn': ['p-item', 'h-item', 'p-name'],  # doesn't work properly, see spec
-        'photo': ['u-photo'],  # of the item being reviewed (p-item h-item u-photo)
-        'url': ['u-url'],  # of the item being reviewed (p-item h-item u-url)
-        'reviewer': ['p-reviewer', 'p-author', 'h-card'],
-        'dtreviewed': ['dt-reviewed'],
-        'rating': ['p-rating'],
-        'best': ['p-best'],
-        'worst': ['p-worst'],
-        'description': ['p-description'],
+        'classes': {
+            'summary': ['p-name'],
+            # doesn't work properly, see spec
+            'fn': ['p-item', 'h-item', 'p-name'],
+            # of the item being reviewed (p-item h-item u-photo)
+            'photo': ['u-photo'],
+            # of the item being reviewed (p-item h-item u-url)
+            'url': ['u-url'],
+            'reviewer': ['p-reviewer', 'p-author', 'h-card'],
+            'dtreviewed': ['dt-reviewed'],
+            'rating': ['p-rating'],
+            'best': ['p-best'],
+            'worst': ['p-worst'],
+            'description': ['p-description'],
+        },
     },
     'hproduct': {
-        'fn': ['p-name'],
-        'photo': ['u-photo'],
-        'brand': ['p-brand'],
-        'category': ['p-category'],
-        'description': ['p-description'],
-        'identifier': ['u-identifier'],
-        'url': ['u-url'],
-        'review': ['p-review', 'h-review', 'e-description'],
-        'price': ['p-price'],
+        'classes': {
+            'fn': ['p-name'],
+            'photo': ['u-photo'],
+            'brand': ['p-brand'],
+            'category': ['p-category'],
+            'description': ['p-description'],
+            'identifier': ['u-identifier'],
+            'url': ['u-url'],
+            'review': ['p-review', 'h-review', 'e-description'],
+            'price': ['p-price'],
+        },
     }
 }
 
@@ -128,13 +150,21 @@ def apply_rules(doc):
 
     def update_child_properties(parent, properties):
         for child in parent.find_all(recursive=False):
-            child_class = child.get('class')
-            for old_prop, new_props in properties.items():
-                if child_class and old_prop in child_class:
-                    for new_prop in new_props:
-                        if new_prop not in child_class:
-                            child_class.append(new_prop)
-
+            child_class = child.get('class', [])
+            # augment legacy class names with their associated mf2 classes
+            for old_prop, new_props in properties.get('classes', {}).items():
+                if old_prop in child_class:
+                    child_class += [p for p in new_props
+                                    if p not in child_class]
+            # check for legacy rel properties (e.g. rel=bookmark that translate
+            # to mf2 classes
+            child_rel = child.get('rel', [])
+            for old_prop, new_props in properties.get('rels', {}).items():
+                if child_rel and old_prop in child_rel:
+                    child_class += [p for p in new_props
+                                    if p not in child_class]
+            if child_class:
+                child['class'] = child_class
             # recurse if it's not a nested root
             if not any(cls in CLASSIC_ROOT_MAP
                        for cls in child.get('class', [])):

--- a/test/examples/backcompat_feed_with_rel_bookmark.html
+++ b/test/examples/backcompat_feed_with_rel_bookmark.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Backcompat test for hEntry with nested rel=bookmark</title>
+    <!-- This should not affect parsing elsewhere -->
+    <link rel="bookmark" href="/about">
+  </head>
+  <body>
+    <!-- This should not affect parsing elsewhere -->
+    <a rel="bookmark" href="/"></a>
+
+    <article class="hentry">
+      <span class="author">Lee Adama</span>
+      <span class="entry-title">Jumping Rope for Weight Loss</span>
+      <div class="entry-content">Some Content</div>
+      <a rel="bookmark" href="/2014/11/24/jump-rope">Nov 24, 2014</a>
+    </article>
+
+    <article class="hentry">
+      <span class="author">Kara Thrace</span>
+      <span class="entry-title">Abstract Art in Graffiti</span>
+      <div class="entry-content">More Content</div>
+      <a rel="bookmark" href="/2014/11/23/graffiti">Nov 23, 2014</a>
+    </article>
+
+    <article class="hentry">
+      <span class="author">President Roslyn</span>
+      <span class="entry-title">Dreams of Earth</span>
+      <div class="entry-content">Additional Content</div>
+      <a rel="bookmark" href="/2014/11/21/earth">Nov 21, 2014</a>
+    </article>
+
+    <article class="hentry">
+      <span class="author">Chief Tyrrol</span>
+      <span class="entry-title">Organized Labor in Mining Colonies</span>
+      <div class="entry-content">More Content</div>
+      <a rel="bookmark" href="/2014/11/19/labor">Nov 19, 2014</a>
+    </article>
+
+  </body>
+</html>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from mf2py.parser import Parser
+from mf2py import Parser
 from nose.tools import assert_equal, assert_true
 from pprint import pprint
 import os.path
@@ -249,14 +249,15 @@ def test_html_tag_class():
     assert_equal([u'entry2'], result['items'][0]['children'][1]['properties']['name'])
 
 
-
 def test_string_strip():
     result = parse_fixture("string_stripping.html")
     assert result["items"][0]["properties"]["name"][0] == "Tom Morris"
 
+
 def test_template_parse():
     result = parse_fixture("template_tag.html")
     assert len(result["items"]) == 0
+
 
 def test_backcompat_hproduct():
     result = parse_fixture("backcompat_hproduct.html")
@@ -268,16 +269,34 @@ def test_backcompat_hproduct():
     assert result["items"][0]["properties"]['description'][0] ==  u"Magical tasty sugar pills that don't do anything."
     assert result["items"][0]["properties"]["name"] == [u"Tom's Magical Quack Tincture"]
 
+
 def test_backcompat_hproduct_nested_hreview():
     result = parse_fixture("backcompat_hproduct_hreview_nested.html")
     assert result["items"][0]["children"][0]['type'] == ['h-review']
     assert type(result["items"][0]["children"][0]['properties']['name'][0]) == text_type
+
+
+def test_backcompat_rel_bookmark():
+    """Confirm that rel=bookmark inside of an h-entry is converted
+    to u-url.
+    """
+    result = parse_fixture('backcompat_feed_with_rel_bookmark.html')
+    for ii, url in enumerate((
+            '/2014/11/24/jump-rope',
+            '/2014/11/23/graffiti',
+            '/2014/11/21/earth',
+            '/2014/11/19/labor',
+    )):
+        assert result['items'][ii]['type'] == ['h-entry']
+        assert result['items'][ii]['properties']['url'] == [url]
+
 
 def test_area_uparsing():
     result = parse_fixture("area.html")
     assert result["items"][0]["properties"] == {u'url': [u'http://suda.co.uk'], u'name': [u'Brian Suda']}
     assert 'shape' in result["items"][0].keys()
     assert 'coords' in result["items"][0].keys()
+
 
 def test_src_equiv():
     result = parse_fixture("test_src_equiv.html")


### PR DESCRIPTION
added an intermediate layer to the CLASSIC_PROPERTY_MAP containing
'classes' and 'rels' where classes are legacy class names to their mf2
equivalent, and rels is the same thing for legacy rel-names.

This covers #45 and should address https://github.com/snarfed/bridgy/issues/309
